### PR TITLE
Fix for latest illuminate/view

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,21 +1,16 @@
 {
-    "name": "ilab/standalone-blade",
+    "name": "ryangjchandler/standalone-blade",
     "description": "Use Laravel's Blade templating engine outside of Laravel.",
     "keywords": [
         "ryangjchandler",
         "standalone-blade"
     ],
-    "homepage": "https://github.com/Interfacelab/standalone-blade",
+    "homepage": "https://github.com/ryangjchandler/standalone-blade",
     "license": "MIT",
     "authors": [
         {
             "name": "Ryan Chandler",
             "email": "support@ryangjchandler.co.uk",
-            "role": "Developer"
-        },
-        {
-            "name": "Jon Gilkison",
-            "email": "jon@interfacelab.com",
             "role": "Developer"
         }
     ],

--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,21 @@
 {
-    "name": "ryangjchandler/standalone-blade",
+    "name": "ilab/standalone-blade",
     "description": "Use Laravel's Blade templating engine outside of Laravel.",
     "keywords": [
         "ryangjchandler",
         "standalone-blade"
     ],
-    "homepage": "https://github.com/ryangjchandler/standalone-blade",
+    "homepage": "https://github.com/Interfacelab/standalone-blade",
     "license": "MIT",
     "authors": [
         {
             "name": "Ryan Chandler",
             "email": "support@ryangjchandler.co.uk",
+            "role": "Developer"
+        },
+        {
+            "name": "Jon Gilkison",
+            "email": "jon@interfacelab.com",
             "role": "Developer"
         }
     ],

--- a/src/Blade.php
+++ b/src/Blade.php
@@ -35,7 +35,7 @@ class Blade
 
     protected function init()
     {
-        $this->container ??= new Container;
+        $this->container ??= new BladeContainer;
 
         $this->container->singleton('files', fn () => new Filesystem);
         $this->container->singleton('events', fn () => new Dispatcher);

--- a/src/Blade.php
+++ b/src/Blade.php
@@ -63,4 +63,8 @@ class Blade
     {
         return new static($viewPath, $cachePath, $container);
     }
+
+    public function teardown() {
+        $this->container->terminate();
+    }
 }

--- a/src/BladeContainer.php
+++ b/src/BladeContainer.php
@@ -5,7 +5,15 @@ namespace RyanChandler\Blade;
 use Illuminate\Container\Container;
 
 class BladeContainer extends Container {
+    /** @var \Closure[] */
+    private $callbacks = [];
     public function terminating(\Closure $func) {
-        $func();
+        $this->callbacks[] = $func;
+    }
+
+    public function terminate() {
+        foreach($this->callbacks as $callback) {
+            $callback();
+        }
     }
 }

--- a/src/BladeContainer.php
+++ b/src/BladeContainer.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace RyanChandler\Blade;
+
+use Illuminate\Container\Container;
+
+class BladeContainer extends Container {
+    public function terminating(\Closure $func) {
+        $func();
+    }
+}


### PR DESCRIPTION
Adds missing `terminating()` function to container.  Adds a `teardown()` method to run the terminating hooks (for cache cleanup typically).